### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig helps developers define and maintain consistent coding styles
+# between different editors and IDEs
+# editorconfig.org
+
+
+# Topmost EditorConfig file
+root = true
+
+# Overall defaults
+[*]
+
+# Tab style
+indent_style = space
+indent_size = 2
+
+# File format and handling
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# HTML
+[*.html]
+indent_size = 4


### PR DESCRIPTION
This PR adds code style instructions for code editors that have [EditorConfig](https://editorconfig.org/) support. I set defaults to what I saw in a brief audit of the repo, but happy to update to match house standards.