### PR TITLE
Fix Django Version for Compatibility with SQLite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ sftp-config.json
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+# virtualenv
+bin/
+include/
+share/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.7.1
 certifi==2019.3.9
 chardet==3.0.4
-Django==2.1
+Django==2.1.5
 djangorestframework==3.9.3
 gunicorn==19.9.0
 idna==2.8


### PR DESCRIPTION
Small gitignore update

Bump Django version to 2.1.5 to handle SQLite/Django incompatibility …
85a8ec7
- This showed up as the error message "No such table:
  main.auth_user__old" when trying to create a new user via the admin portal
- https://stackoverflow.com/questions/53637182/django-no-such-table-main-auth-user-old
- New setups should work fine
- To fix existing (broken) setups, run the following command:
  `pip install -r requirements.txt && rm db.sqlite3 && python manage.py migrate`