### PR TITLE
Explicitly specify csv encoding to avoid platform specific decode errors

### DIFF
--- a/apps/civic_pulse/utils/load_models.py
+++ b/apps/civic_pulse/utils/load_models.py
@@ -17,7 +17,7 @@ def fill_agency_objects(
     filepath=os.path.join(os.path.dirname(__file__), "../data/agencies.csv")
 ):
 
-    with open(filepath) as file:
+    with open(filepath, encoding='utf-8') as file:
         reader = csv.reader(file)
         next(reader, None)  # skip the headers
 


### PR DESCRIPTION
Windows computers use a different default encoding to open files. This explicitly specifies UTF-8 to avoid errors that Windows users have had.