### PR TITLE
Add flake8 to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,10 @@ repos:
     hooks:
     - id: black
       language_version: python3
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7-maintenance
+    hooks:
+    - id: flake8
+      args:
+      - '--ignore'
+      - 'E501,W503,E203'


### PR DESCRIPTION
## Changes

This PR adds `flake8` linting to `pre-commit` to reflect that `flake8` runs on our CI. The chosen revision of `3.7-maintenance` is good because it is being maintained. I chose not to use the `stable/2.6` revision from `flake8`, because that branch does not require the `.pre-commit-hooks.yaml` file required by `pre-commit`.

After this is merged, `flake8` will be run anytime someone (with pre-commit configured) runs `git commit`.

## Testing

If you want to test this out, clone the PR and run the following:

```
pip install pre-commit
pre-commit install
pre-commit run --all-files
```